### PR TITLE
Changed (views.py): so GET /api/v1/profile/me/ no longer returns 404 …

### DIFF
--- a/apps/profile/views.py
+++ b/apps/profile/views.py
@@ -16,16 +16,9 @@ class MeProfileView(APIView):
         user = request.user
         try:
             profile = user.profile
-            if profile.is_empty():
-                return Response(
-                    {"detail": "No profile yet. Update to create one."},
-                    status=status.HTTP_404_NOT_FOUND,
-                )
         except UserProfile.DoesNotExist:
-            return Response(
-                {"detail": "No profile yet. Update to create one."},
-                status=status.HTTP_404_NOT_FOUND,
-            )
+            # Return an empty/default profile payload so clients can render/edit immediately.
+            profile = UserProfile(user=user)
         serializer = UserProfileSerializer(profile)
         return Response(serializer.data)
 


### PR DESCRIPTION
…for an empty/missing profile.

- If profile exists: returns 200 with profile data
- If profile does not exist yet: returns 200 with an empty/default profile payload (so mobile can render and edit)
- PATCH behavior stays the same (user can create/update profile)